### PR TITLE
Fix: kn was not downloaded properly during install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM apache/airflow:2.4.3
 USER root
-RUN curl -o kn https://github.com/knative/client/releases/download/knative-v1.4.0/kn-linux-amd64 && chmod +x kn && mv kn /usr/local/bin/kn
+RUN curl -o kn -L https://github.com/knative/client/releases/download/knative-v1.4.0/kn-linux-amd64 && chmod +x kn && mv kn /usr/local/bin/kn
 USER airflow
 COPY airflow /home/airflow/.local/lib/python3.7/site-packages/airflow


### PR DESCRIPTION
curl should follow redirects when downloading the kn binary from github